### PR TITLE
KVP: Standardize KVP keys with hlvmm prefix and implement fully dynamic key handling

### DIFF
--- a/Linux/user-data
+++ b/Linux/user-data
@@ -316,22 +316,29 @@ write_files:
           # Debug: Show AES key length for verification
           echo "DEBUG: Decrypted AES key length: $aes_key_size bytes"
 
-          # Define the keys to decrypt with new standardized names
-          keys_to_decrypt=(
-              "hlvmm.data.guest_host_name"
-              "hlvmm.data.guest_v4_ip_addr"
-              "hlvmm.data.guest_v4_cidr_prefix"
-              "hlvmm.data.guest_v4_default_gw"
-              "hlvmm.data.guest_v4_dns1"
-              "hlvmm.data.guest_v4_dns2"
-              "hlvmm.data.guest_net_dns_suffix"
-              "hlvmm.data.guest_domain_join_target"
-              "hlvmm.data.guest_domain_join_uid"
-              "hlvmm.data.guest_domain_join_pw"
-              "hlvmm.data.guest_domain_join_ou"
-              "hlvmm.data.guest_la_uid"
-              "hlvmm.data.guest_la_pw"
-          )
+          # Get all hlvmm.data keys dynamically instead of using hardcoded list
+          hlvmm_data_keys=()
+          local kvp_file="/var/lib/hyperv/.kvp_pool_0"
+          
+          if [[ -f "$kvp_file" ]]; then
+              local nb=$(wc -c < "$kvp_file")
+              local nkv=$(( nb / (512+2048) ))
+              
+              for n in $(seq 0 $(( $nkv - 1 )) ); do
+                  local offset=$(( $n * (512 + 2048) ))
+                  local k=$(dd if="$kvp_file" count=512 bs=1 skip=$offset status=none | sed 's/\x0.*//g')
+                  if [[ "$k" == hlvmm.data.* ]]; then
+                      hlvmm_data_keys+=("$k")
+                  fi
+              done
+          fi
+          
+          if [[ ${#hlvmm_data_keys[@]} -eq 0 ]]; then
+              echo "ERROR: No hlvmm.data keys found in KVP. Cannot proceed with provisioning."
+              return 1
+          fi
+          
+          echo "Found ${#hlvmm_data_keys[@]} hlvmm.data keys to decrypt"
 
           # Directory to store decrypted keys
           decrypted_keys_dir="/var/lib/hyperv/decrypted_keys"
@@ -353,33 +360,17 @@ write_files:
           # Clean up temporary AES key file
           rm -f "$temp_aes_key"
 
-          # Create mapping from new KVP key names to legacy filenames for backward compatibility
-          declare -A key_to_filename_mapping=(
-              ["hlvmm.data.guest_host_name"]="guesthostname"
-              ["hlvmm.data.guest_v4_ip_addr"]="guestv4ipaddr"
-              ["hlvmm.data.guest_v4_cidr_prefix"]="guestv4cidrprefix"
-              ["hlvmm.data.guest_v4_default_gw"]="guestv4defaultgw"
-              ["hlvmm.data.guest_v4_dns1"]="guestv4dns1"
-              ["hlvmm.data.guest_v4_dns2"]="guestv4dns2"
-              ["hlvmm.data.guest_net_dns_suffix"]="guestnetdnssuffix"
-              ["hlvmm.data.guest_domain_join_target"]="guestdomainjointarget"
-              ["hlvmm.data.guest_domain_join_uid"]="guestdomainjoinuid"
-              ["hlvmm.data.guest_domain_join_pw"]="guestdomainjoinpw"
-              ["hlvmm.data.guest_domain_join_ou"]="guestdomainjoinou"
-              ["hlvmm.data.guest_la_uid"]="guestlauid"
-              ["hlvmm.data.guest_la_pw"]="guestlapw"
-          )
-
-          # Save each decrypted key to a file
+          # Save each decrypted key to a file using the actual KVP key name
           echo "Decrypting provisioning data keys..."
-          for key in "${keys_to_decrypt[@]}"; do
+          for key in "${hlvmm_data_keys[@]}"; do
               encrypted_value=$(read_hyperv_kvp "$key")
-              legacy_filename="${key_to_filename_mapping[$key]}"
+              # Create safe filename by replacing dots with underscores  
+              safe_filename=$(echo "$key" | sed 's/\./_/g')
               if [[ -n "$encrypted_value" ]]; then
                   # Use temporary files to handle binary data properly and avoid shell variable issues
-                  temp_encrypted="/tmp/encrypted_$legacy_filename"
-                  temp_iv="/tmp/iv_$legacy_filename"
-                  temp_ciphertext="/tmp/ciphertext_$legacy_filename"
+                  temp_encrypted="/tmp/encrypted_$safe_filename"
+                  temp_iv="/tmp/iv_$safe_filename"
+                  temp_ciphertext="/tmp/ciphertext_$safe_filename"
                   
                   # Decode base64 to temporary file
                   echo "$encrypted_value" | base64 -d > "$temp_encrypted"
@@ -388,7 +379,7 @@ write_files:
                   encrypted_size=$(stat -c%s "$temp_encrypted" 2>/dev/null || echo "0")
                   if [[ $encrypted_size -lt 16 ]]; then
                       echo "ERROR: Invalid encrypted data for $key (size: $encrypted_size bytes)"
-                      touch "$decrypted_keys_dir/$legacy_filename"
+                      touch "$decrypted_keys_dir/$safe_filename"
                       rm -f "$temp_encrypted" "$temp_iv" "$temp_ciphertext"
                       continue
                   fi
@@ -402,20 +393,20 @@ write_files:
                   
                   # Decrypt using AES-256-CBC (try with PKCS7 padding first, then no padding)
                   if decrypted_value=$(openssl enc -d -aes-256-cbc -K "$aes_key_hex" -iv "$iv_hex" -in "$temp_ciphertext" 2>/dev/null); then
-                      echo "$decrypted_value" > "$decrypted_keys_dir/$legacy_filename"
-                      echo "Successfully decrypted $key"
+                      echo "$decrypted_value" > "$decrypted_keys_dir/$safe_filename"
+                      echo "Successfully decrypted $key -> $safe_filename"
                   elif decrypted_value=$(openssl enc -d -aes-256-cbc -K "$aes_key_hex" -iv "$iv_hex" -nopad -in "$temp_ciphertext" 2>/dev/null | sed 's/\x00*$//'); then
-                      echo "$decrypted_value" > "$decrypted_keys_dir/$legacy_filename"
-                      echo "Successfully decrypted $key (with nopad)"
+                      echo "$decrypted_value" > "$decrypted_keys_dir/$safe_filename"  
+                      echo "Successfully decrypted $key -> $safe_filename (with nopad)"
                   else
                       echo "ERROR: Failed to decrypt value for $key"
-                      touch "$decrypted_keys_dir/$legacy_filename"
+                      touch "$decrypted_keys_dir/$safe_filename"
                   fi
                   
                   # Clean up temporary files
                   rm -f "$temp_encrypted" "$temp_iv" "$temp_ciphertext"
               else
-                  touch "$decrypted_keys_dir/$legacy_filename"
+                  touch "$decrypted_keys_dir/$safe_filename"
               fi
           done
 
@@ -434,9 +425,9 @@ write_files:
           
           # Get all decrypted hlvmm.data values and sort by key name for consistent ordering
           declare -A data_values
-          for key in "${keys_to_decrypt[@]}"; do
-              legacy_filename="${key_to_filename_mapping[$key]}"
-              data_values["$key"]="$(read_file_safe "$decrypted_keys_dir/$legacy_filename")"
+          for key in "${hlvmm_data_keys[@]}"; do
+              safe_filename=$(echo "$key" | sed 's/\./_/g')
+              data_values["$key"]="$(read_file_safe "$decrypted_keys_dir/$safe_filename")"
           done
           
           # Sort keys and concatenate values
@@ -465,8 +456,8 @@ write_files:
           echo "Checksum verification succeeded."
 
           # Configure local admin account if credentials are provided and non-empty
-          local_admin_user=$(read_file_safe "$decrypted_keys_dir/guestlauid" | tr -d '\0\r\n' | xargs)
-          local_admin_password=$(read_file_safe "$decrypted_keys_dir/guestlapw" | tr -d '\0\r\n' | xargs)
+          local_admin_user=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_la_uid" | tr -d '\0\r\n' | xargs)
+          local_admin_password=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_la_pw" | tr -d '\0\r\n' | xargs)
 
           if [[ -n "$local_admin_user" && -n "$local_admin_password" ]]; then
               if id "$local_admin_user" &>/dev/null; then
@@ -493,18 +484,18 @@ write_files:
           fi
 
           # Ignore domain join parameters
-          if [[ -f "$decrypted_keys_dir/guestdomainjointarget" || -f "$decrypted_keys_dir/guestdomainjoinuid" || -f "$decrypted_keys_dir/guestdomainjoinpw" ]]; then
+          if [[ -f "$decrypted_keys_dir/hlvmm_data_guest_domain_join_target" || -f "$decrypted_keys_dir/hlvmm_data_guest_domain_join_uid" || -f "$decrypted_keys_dir/hlvmm_data_guest_domain_join_pw" ]]; then
               echo "Domain join parameters detected but ignored (not supported on Linux)."
           fi
 
           # Configure the network with netplan if IP settings are complete and valid
           # Read network configuration values safely
-          ip_address=$(read_file_safe "$decrypted_keys_dir/guestv4ipaddr" | tr -d '\0\r\n' | xargs)
-          cidr_prefix=$(read_file_safe "$decrypted_keys_dir/guestv4cidrprefix" | tr -d '\0\r\n' | xargs)
-          default_gateway=$(read_file_safe "$decrypted_keys_dir/guestv4defaultgw" | tr -d '\0\r\n' | xargs)
-          dns1=$(read_file_safe "$decrypted_keys_dir/guestv4dns1" | tr -d '\0\r\n' | xargs)
-          dns2=$(read_file_safe "$decrypted_keys_dir/guestv4dns2" | tr -d '\0\r\n' | xargs)
-          dns_suffix=$(read_file_safe "$decrypted_keys_dir/guestnetdnssuffix" | tr -d '\0\r\n' | xargs)
+          ip_address=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_v4_ip_addr" | tr -d '\0\r\n' | xargs)
+          cidr_prefix=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_v4_cidr_prefix" | tr -d '\0\r\n' | xargs)
+          default_gateway=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_v4_default_gw" | tr -d '\0\r\n' | xargs)
+          dns1=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_v4_dns1" | tr -d '\0\r\n' | xargs)
+          dns2=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_v4_dns2" | tr -d '\0\r\n' | xargs)
+          dns_suffix=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_net_dns_suffix" | tr -d '\0\r\n' | xargs)
           
           # Check if all required network parameters are provided and non-empty
           if [[ -n "$ip_address" && -n "$cidr_prefix" && -n "$default_gateway" ]]; then
@@ -571,7 +562,7 @@ write_files:
           fi
 
           # Set the hostname if it is provided and non-empty
-          hostname=$(read_file_safe "$decrypted_keys_dir/guesthostname" | tr -d '\0\r\n' | xargs)
+          hostname=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_host_name" | tr -d '\0\r\n' | xargs)
           if [[ -n "$hostname" ]]; then
               echo "$hostname" > /etc/hostname
               hostnamectl set-hostname "$hostname"

--- a/Linux/user-data
+++ b/Linux/user-data
@@ -421,18 +421,39 @@ write_files:
           }
 
           # Verify the checksum of the provisioning data (calculated from all hlvmm.data values)
+          echo "=== CHECKSUM VERIFICATION DEBUG ==="
           echo "Verifying provisioning data checksum..."
           
           # Get all decrypted hlvmm.data values and sort by key name for consistent ordering
+          # IMPORTANT: Only include keys with non-empty values (matching PowerShell logic)
           declare -A data_values
+          echo "DEBUG: Processing hlvmm.data keys..."
           for key in "${hlvmm_data_keys[@]}"; do
               safe_filename=$(echo "$key" | sed 's/\./_/g')
-              data_values["$key"]="$(read_file_safe "$decrypted_keys_dir/$safe_filename")"
+              value=$(read_file_safe "$decrypted_keys_dir/$safe_filename")
+              
+              # Trim whitespace and check if non-empty (matching PowerShell [string]::IsNullOrWhiteSpace logic)
+              trimmed_value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              
+              echo "DEBUG: Key: '$key' -> Value length: ${#value} chars (trimmed: ${#trimmed_value})"
+              echo "DEBUG:   Value preview: '${value:0:20}$([ ${#value} -gt 20 ] && echo "...")'"
+              
+              # Only include in checksum if value is non-empty after trimming
+              if [[ -n "$trimmed_value" ]]; then
+                  data_values["$key"]="$value"
+                  echo "DEBUG:   -> INCLUDED in checksum calculation"
+              else
+                  echo "DEBUG:   -> EXCLUDED from checksum (empty/whitespace only)"
+              fi
           done
           
           # Sort keys and concatenate values
+          echo "DEBUG: Building concatenated data in sorted key order..."
           concatenated_data=""
-          for key in $(printf '%s\n' "${!data_values[@]}" | sort); do
+          sorted_keys=($(printf '%s\n' "${!data_values[@]}" | sort))
+          
+          for key in "${sorted_keys[@]}"; do
+              echo "DEBUG: Processing key '$key' for concatenation"
               if [[ -n "$concatenated_data" ]]; then
                   concatenated_data="${concatenated_data}|${data_values[$key]}"
               else
@@ -440,20 +461,45 @@ write_files:
               fi
           done
 
+          echo "DEBUG: Concatenated data for checksum:"
+          echo "DEBUG:   Length: ${#concatenated_data} chars"
+          echo "DEBUG:   Content: '${concatenated_data:0:200}$([ ${#concatenated_data} -gt 200 ] && echo "...")'"
+
           # Calculate checksum and encode as Base64 (to match Windows version)
-          calculated_checksum=$(echo -n "$concatenated_data" | sha256sum -b | awk '{print $1}' | xxd -r -p | base64 -w 0)          
+          echo "DEBUG: Calculating SHA256 checksum..."
+          
+          # Use a more explicit approach to avoid encoding issues
+          temp_data_file="/tmp/checksum_data"
+          printf '%s' "$concatenated_data" > "$temp_data_file"
+          
+          # Calculate SHA256 hash
+          hash_hex=$(sha256sum "$temp_data_file" | awk '{print $1}')
+          echo "DEBUG: SHA256 hash (hex): $hash_hex"
+          
+          # Convert hex to binary and then to Base64
+          calculated_checksum=$(echo "$hash_hex" | xxd -r -p | base64 -w 0)
+          echo "DEBUG: Checksum (Base64): $calculated_checksum"
+          
+          # Clean up temp file
+          rm -f "$temp_data_file"
+          
           published_checksum=$(read_hyperv_kvp "hlvmm.meta.provisioning_system_checksum")
+          echo "DEBUG: Published checksum from KVP: $published_checksum"
 
           if [[ "$calculated_checksum" != "$published_checksum" ]]; then
               echo "ERROR: Checksum verification failed!"
               echo "Expected: $published_checksum"
               echo "Got:      $calculated_checksum"
-              echo "DEBUG: Concatenated data length: ${#concatenated_data} characters"
-              echo "DEBUG: First 100 chars of concatenated data: ${concatenated_data:0:100}"
+              echo "DEBUG: Hex comparison:"
+              echo "DEBUG:   Expected hex: $(echo "$published_checksum" | base64 -d | xxd -p -c 32)"
+              echo "DEBUG:   Got hex:      $hash_hex"
+              echo "DEBUG: Key count comparison:"
+              echo "DEBUG:   Found ${#hlvmm_data_keys[@]} hlvmm.data keys"
+              echo "DEBUG:   Keys: $(printf '%s ' "${sorted_keys[@]}")"
               return 1
           fi
 
-          echo "Checksum verification succeeded."
+          echo "DEBUG: Checksum verification succeeded!"
 
           # Configure local admin account if credentials are provided and non-empty
           local_admin_user=$(read_file_safe "$decrypted_keys_dir/hlvmm_data_guest_la_uid" | tr -d '\0\r\n' | xargs)

--- a/Linux/user-data
+++ b/Linux/user-data
@@ -173,13 +173,13 @@ write_files:
           # Eject CD-ROM drives early to prevent interference with reboots
           eject_cdroms
 
-          # Wait until hostprovisioningsystemstate equals waitingforpublickey
+          # Wait until hlvmm.meta.host_provisioning_system_state equals waitingforpublickey
           echo "Waiting for host to signal 'waitingforpublickey'..."
           local timeout=300 # 5 minutes
           local elapsed=0
           
           while true; do
-              host_state=$(read_hyperv_kvp "hostprovisioningsystemstate")
+              host_state=$(read_hyperv_kvp "hlvmm.meta.host_provisioning_system_state")
               
               if [[ "$host_state" == "waitingforpublickey" ]]; then
                   echo "Host is ready for public key exchange"
@@ -244,31 +244,31 @@ write_files:
           echo "Converting public key to Base64 format..."
           public_key_der=$(openssl rsa -pubin -in "$public_key" -RSAPublicKey_out -outform DER | base64 -w 0)
 
-          # Publish the public key to guestprovisioningpublickey in KVP
+          # Publish the public key to hlvmm.meta.guest_provisioning_public_key in KVP
           echo "Publishing public key to KVP..."
-          if write_hyperv_kvp "guestprovisioningpublickey" "$public_key_der"; then
+          if write_hyperv_kvp "hlvmm.meta.guest_provisioning_public_key" "$public_key_der"; then
               echo "Public key published successfully"
           else
               echo "ERROR: Failed to publish public key"
               return 1
           fi
 
-          # Set guestprovisioningsystemstate to waitingforaeskey (note: correct key name!)
+          # Set hlvmm.meta.guest_provisioning_system_state to waitingforaeskey
           echo "Setting guest state to 'waitingforaeskey'..."
-          if write_hyperv_kvp "guestprovisioningsystemstate" "waitingforaeskey"; then
+          if write_hyperv_kvp "hlvmm.meta.guest_provisioning_system_state" "waitingforaeskey"; then
               echo "Guest state set successfully"
           else
               echo "ERROR: Failed to set guest state"
               return 1
           fi
 
-          # Wait for hostprovisioningsystemstate to equal provisioningdatapublished (note: correct key name!)
+          # Wait for hlvmm.meta.host_provisioning_system_state to equal provisioningdatapublished
           echo "Waiting for host to publish provisioning data..."
           timeout=300 # 5 minutes
           elapsed=0
           
           while true; do
-              host_state=$(read_hyperv_kvp "hostprovisioningsystemstate")
+              host_state=$(read_hyperv_kvp "hlvmm.meta.host_provisioning_system_state")
               
               if [[ "$host_state" == "provisioningdatapublished" ]]; then
                   echo "Host has published provisioning data"
@@ -286,7 +286,7 @@ write_files:
 
           # Read the shared AES key from KVP
           echo "Reading shared AES key from KVP..."
-          shared_aes_key=$(read_hyperv_kvp "sharedaeskey")
+          shared_aes_key=$(read_hyperv_kvp "hlvmm.meta.shared_aes_key")
           if [[ -z "$shared_aes_key" ]]; then
               echo "ERROR: Shared AES key not found in KVP"
               return 1
@@ -316,21 +316,21 @@ write_files:
           # Debug: Show AES key length for verification
           echo "DEBUG: Decrypted AES key length: $aes_key_size bytes"
 
-          # Define the keys to decrypt (must match exactly with Windows PowerShell version)
+          # Define the keys to decrypt with new standardized names
           keys_to_decrypt=(
-              "guesthostname"
-              "guestv4ipaddr"
-              "guestv4cidrprefix"
-              "guestv4defaultgw"
-              "guestv4dns1"
-              "guestv4dns2"
-              "guestnetdnssuffix"
-              "guestdomainjointarget"
-              "guestdomainjoinuid"
-              "guestdomainjoinpw"
-              "guestdomainjoinou"
-              "guestlauid"
-              "guestlapw"
+              "hlvmm.data.guest_host_name"
+              "hlvmm.data.guest_v4_ip_addr"
+              "hlvmm.data.guest_v4_cidr_prefix"
+              "hlvmm.data.guest_v4_default_gw"
+              "hlvmm.data.guest_v4_dns1"
+              "hlvmm.data.guest_v4_dns2"
+              "hlvmm.data.guest_net_dns_suffix"
+              "hlvmm.data.guest_domain_join_target"
+              "hlvmm.data.guest_domain_join_uid"
+              "hlvmm.data.guest_domain_join_pw"
+              "hlvmm.data.guest_domain_join_ou"
+              "hlvmm.data.guest_la_uid"
+              "hlvmm.data.guest_la_pw"
           )
 
           # Directory to store decrypted keys
@@ -353,15 +353,33 @@ write_files:
           # Clean up temporary AES key file
           rm -f "$temp_aes_key"
 
+          # Create mapping from new KVP key names to legacy filenames for backward compatibility
+          declare -A key_to_filename_mapping=(
+              ["hlvmm.data.guest_host_name"]="guesthostname"
+              ["hlvmm.data.guest_v4_ip_addr"]="guestv4ipaddr"
+              ["hlvmm.data.guest_v4_cidr_prefix"]="guestv4cidrprefix"
+              ["hlvmm.data.guest_v4_default_gw"]="guestv4defaultgw"
+              ["hlvmm.data.guest_v4_dns1"]="guestv4dns1"
+              ["hlvmm.data.guest_v4_dns2"]="guestv4dns2"
+              ["hlvmm.data.guest_net_dns_suffix"]="guestnetdnssuffix"
+              ["hlvmm.data.guest_domain_join_target"]="guestdomainjointarget"
+              ["hlvmm.data.guest_domain_join_uid"]="guestdomainjoinuid"
+              ["hlvmm.data.guest_domain_join_pw"]="guestdomainjoinpw"
+              ["hlvmm.data.guest_domain_join_ou"]="guestdomainjoinou"
+              ["hlvmm.data.guest_la_uid"]="guestlauid"
+              ["hlvmm.data.guest_la_pw"]="guestlapw"
+          )
+
           # Save each decrypted key to a file
           echo "Decrypting provisioning data keys..."
           for key in "${keys_to_decrypt[@]}"; do
               encrypted_value=$(read_hyperv_kvp "$key")
+              legacy_filename="${key_to_filename_mapping[$key]}"
               if [[ -n "$encrypted_value" ]]; then
                   # Use temporary files to handle binary data properly and avoid shell variable issues
-                  temp_encrypted="/tmp/encrypted_$key"
-                  temp_iv="/tmp/iv_$key"
-                  temp_ciphertext="/tmp/ciphertext_$key"
+                  temp_encrypted="/tmp/encrypted_$legacy_filename"
+                  temp_iv="/tmp/iv_$legacy_filename"
+                  temp_ciphertext="/tmp/ciphertext_$legacy_filename"
                   
                   # Decode base64 to temporary file
                   echo "$encrypted_value" | base64 -d > "$temp_encrypted"
@@ -370,7 +388,7 @@ write_files:
                   encrypted_size=$(stat -c%s "$temp_encrypted" 2>/dev/null || echo "0")
                   if [[ $encrypted_size -lt 16 ]]; then
                       echo "ERROR: Invalid encrypted data for $key (size: $encrypted_size bytes)"
-                      touch "$decrypted_keys_dir/$key"
+                      touch "$decrypted_keys_dir/$legacy_filename"
                       rm -f "$temp_encrypted" "$temp_iv" "$temp_ciphertext"
                       continue
                   fi
@@ -384,20 +402,20 @@ write_files:
                   
                   # Decrypt using AES-256-CBC (try with PKCS7 padding first, then no padding)
                   if decrypted_value=$(openssl enc -d -aes-256-cbc -K "$aes_key_hex" -iv "$iv_hex" -in "$temp_ciphertext" 2>/dev/null); then
-                      echo "$decrypted_value" > "$decrypted_keys_dir/$key"
+                      echo "$decrypted_value" > "$decrypted_keys_dir/$legacy_filename"
                       echo "Successfully decrypted $key"
                   elif decrypted_value=$(openssl enc -d -aes-256-cbc -K "$aes_key_hex" -iv "$iv_hex" -nopad -in "$temp_ciphertext" 2>/dev/null | sed 's/\x00*$//'); then
-                      echo "$decrypted_value" > "$decrypted_keys_dir/$key"
+                      echo "$decrypted_value" > "$decrypted_keys_dir/$legacy_filename"
                       echo "Successfully decrypted $key (with nopad)"
                   else
                       echo "ERROR: Failed to decrypt value for $key"
-                      touch "$decrypted_keys_dir/$key"
+                      touch "$decrypted_keys_dir/$legacy_filename"
                   fi
                   
                   # Clean up temporary files
                   rm -f "$temp_encrypted" "$temp_iv" "$temp_ciphertext"
               else
-                  touch "$decrypted_keys_dir/$key"
+                  touch "$decrypted_keys_dir/$legacy_filename"
               fi
           done
 
@@ -411,28 +429,29 @@ write_files:
               fi
           }
 
-          # Verify the checksum of the provisioning data (must match PowerShell order exactly)
+          # Verify the checksum of the provisioning data (calculated from all hlvmm.data values)
           echo "Verifying provisioning data checksum..."
           
-          concatenated_data=$(printf "%s|" \
-              "$(read_file_safe "$decrypted_keys_dir/guesthostname")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestv4ipaddr")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestv4cidrprefix")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestv4defaultgw")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestv4dns1")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestv4dns2")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestnetdnssuffix")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestdomainjointarget")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestdomainjoinuid")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestdomainjoinpw")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestdomainjoinou")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestlauid")" \
-              "$(read_file_safe "$decrypted_keys_dir/guestlapw")")
-          concatenated_data=${concatenated_data%|} # Remove trailing pipe
+          # Get all decrypted hlvmm.data values and sort by key name for consistent ordering
+          declare -A data_values
+          for key in "${keys_to_decrypt[@]}"; do
+              legacy_filename="${key_to_filename_mapping[$key]}"
+              data_values["$key"]="$(read_file_safe "$decrypted_keys_dir/$legacy_filename")"
+          done
+          
+          # Sort keys and concatenate values
+          concatenated_data=""
+          for key in $(printf '%s\n' "${!data_values[@]}" | sort); do
+              if [[ -n "$concatenated_data" ]]; then
+                  concatenated_data="${concatenated_data}|${data_values[$key]}"
+              else
+                  concatenated_data="${data_values[$key]}"
+              fi
+          done
 
           # Calculate checksum and encode as Base64 (to match Windows version)
           calculated_checksum=$(echo -n "$concatenated_data" | sha256sum -b | awk '{print $1}' | xxd -r -p | base64 -w 0)          
-          published_checksum=$(read_hyperv_kvp "provisioningsystemchecksum")
+          published_checksum=$(read_hyperv_kvp "hlvmm.meta.provisioning_system_checksum")
 
           if [[ "$calculated_checksum" != "$published_checksum" ]]; then
               echo "ERROR: Checksum verification failed!"

--- a/Powershell/PublishProvisioningData.ps1
+++ b/Powershell/PublishProvisioningData.ps1
@@ -305,8 +305,8 @@ foreach ($paramName in $keysToPublish) {
     $kvpKeyName = "hlvmm.data." + ($paramName -creplace '([A-Z])', '_$1').ToLower().TrimStart('_')
     
     Write-Host "DEBUG: Parameter '$paramName' -> KVP key '$kvpKeyName'"
-    Write-Host "DEBUG:   Value length: $($paramValue.Length if $paramValue else 0) chars"
-    Write-Host "DEBUG:   Value preview: '$($paramValue.Substring(0, [Math]::Min(20, $paramValue.Length)) if $paramValue else '<empty>')$(if ($paramValue.Length -gt 20) { '...' })'"
+    Write-Host "DEBUG:   Value length: $(if ($paramValue) { $paramValue.Length } else { 0 }) chars"
+    Write-Host "DEBUG:   Value preview: '$(if ($paramValue) { $paramValue.Substring(0, [Math]::Min(20, $paramValue.Length)) } else { '<empty>' })$(if ($paramValue -and $paramValue.Length -gt 20) { '...' })'"
     
     if (-not [string]::IsNullOrWhiteSpace($paramValue)) {
         $dataKeysForChecksum += @{ Key = $kvpKeyName; Value = $paramValue }

--- a/Powershell/PublishProvisioningData.ps1
+++ b/Powershell/PublishProvisioningData.ps1
@@ -316,13 +316,22 @@ foreach ($paramName in $keysToPublish) {
     }
 }
 
-# Sort by key name to ensure consistent ordering
-$sortedDataKeys = $dataKeysForChecksum | Sort-Object Key
+# Debug: Show keys before sorting
+Write-Host "DEBUG: Keys before sorting:"
+foreach ($item in $dataKeysForChecksum) {
+    Write-Host "DEBUG:   Unsorted Key: '$($item.Key)'"
+}
+
+# Sort by key name to ensure consistent ordering (using culture-invariant sort)
+$sortedDataKeys = $dataKeysForChecksum | Sort-Object Key -Culture ([System.Globalization.CultureInfo]::InvariantCulture)
 
 Write-Host "DEBUG: Keys included in checksum calculation (sorted):"
+$keyOrder = @()
 foreach ($item in $sortedDataKeys) {
     Write-Host "DEBUG:   Key: '$($item.Key)' -> Value length: $($item.Value.Length) chars"
+    $keyOrder += $item.Key
 }
+Write-Host "DEBUG: Final PowerShell key order for checksum: $($keyOrder -join '|')"
 
 # Concatenate all hlvmm.data values in sorted key order
 $provisioningData = ($sortedDataKeys | ForEach-Object { $_.Value }) -join "|"

--- a/Powershell/WaitForProvisioningKey.ps1
+++ b/Powershell/WaitForProvisioningKey.ps1
@@ -114,7 +114,7 @@ function Get-VMKeyValuePair {
 
 # Set the KVP HostProvisioningSystemState to "Waitingforpublickey"
 Write-Host "Setting up provisioning KVP values for VM '$VMName'..."
-Set-VMKeyValuePair -VMName $VMName -Name "hostprovisioningsystemstate" -Value "waitingforpublickey"
+Set-VMKeyValuePair -VMName $VMName -Name "hlvmm.meta.host_provisioning_system_state" -Value "waitingforpublickey"
 $scriptsVersionPath = Join-Path -Path $PSScriptRoot -ChildPath "scriptsversion"
 if (Test-Path $scriptsVersionPath) {
     $scriptsVersion = Get-Content $scriptsVersionPath -Raw
@@ -132,7 +132,7 @@ Write-Host "Waiting for guest provisioning to reach 'waitingforaeskey' state (ti
 
 while ($elapsedTime -lt $timeout) {
     # Get the current GuestProvisioningSystemState
-    $guestState = Get-VMKeyValuePair -VMName $VMName -Name "guestprovisioningsystemstate"
+    $guestState = Get-VMKeyValuePair -VMName $VMName -Name "hlvmm.meta.guest_provisioning_system_state"
 
     if ($guestState -eq "waitingforaeskey") {
         Write-Host "Guest provisioning state reached 'waitingforaeskey'. Setup complete."
@@ -141,7 +141,7 @@ while ($elapsedTime -lt $timeout) {
     
     # Show progress every 30 seconds
     if ($elapsedTime % 30 -eq 0) {
-        $publicKey = Get-VMKeyValuePair -VMName $VMName -Name "guestprovisioningpublickey"
+        $publicKey = Get-VMKeyValuePair -VMName $VMName -Name "hlvmm.meta.guest_provisioning_public_key"
         $statusMsg = "Elapsed: $($elapsedTime)s"
         if ($guestState) { $statusMsg += ", State: '$guestState'" }
         if ($publicKey) { $statusMsg += ", Public key received" }
@@ -154,8 +154,8 @@ while ($elapsedTime -lt $timeout) {
 }
 
 # Timeout reached
-$finalState = Get-VMKeyValuePair -VMName $VMName -Name "guestprovisioningsystemstate"
-$finalPublicKey = Get-VMKeyValuePair -VMName $VMName -Name "guestprovisioningpublickey"
+$finalState = Get-VMKeyValuePair -VMName $VMName -Name "hlvmm.meta.guest_provisioning_system_state"
+$finalPublicKey = Get-VMKeyValuePair -VMName $VMName -Name "hlvmm.meta.guest_provisioning_public_key"
 
 Write-Error "Timeout reached after $($timeout/60) minutes. Guest did not reach 'waitingforaeskey' state."
 Write-Host "Final status - State: '$finalState', Public key: $(if ($finalPublicKey) { "received" } else { "not received" })"

--- a/Schemas/kvp.txt
+++ b/Schemas/kvp.txt
@@ -1,2 +1,21 @@
-namespace        pool        key         purpose
-hlvmm.meta       host        version     used to verify guest agent version matches host scripts
+namespace        pool        key                                     purpose
+hlvmm.meta       host        version                                 used to verify guest agent version matches host scripts
+hlvmm.meta       host        host_provisioning_system_state        state of host provisioning system (waitingforpublickey, provisioningdatapublished)
+hlvmm.meta       guest       guest_provisioning_system_state       state of guest provisioning system (waitingforaeskey)
+hlvmm.meta       host        shared_aes_key                         wrapped AES key for encrypting provisioning data
+hlvmm.meta       guest       guest_provisioning_public_key         RSA public key from guest for key wrapping
+hlvmm.meta       host        provisioning_system_checksum          SHA256 checksum of all hlvmm.data keys
+
+hlvmm.data       host        guest_host_name                        hostname to set on guest
+hlvmm.data       host        guest_v4_ip_addr                       IPv4 address for guest
+hlvmm.data       host        guest_v4_cidr_prefix                   CIDR prefix for guest IP
+hlvmm.data       host        guest_v4_default_gw                    default gateway for guest
+hlvmm.data       host        guest_v4_dns1                          primary DNS server for guest
+hlvmm.data       host        guest_v4_dns2                          secondary DNS server for guest
+hlvmm.data       host        guest_net_dns_suffix                   DNS suffix for guest network
+hlvmm.data       host        guest_domain_join_target               domain to join guest to
+hlvmm.data       host        guest_domain_join_uid                  username for domain join
+hlvmm.data       host        guest_domain_join_pw                   password for domain join
+hlvmm.data       host        guest_domain_join_ou                   organizational unit for domain join
+hlvmm.data       host        guest_la_uid                           local administrator username
+hlvmm.data       host        guest_la_pw                            local administrator password

--- a/Windows/ProvisioningService.ps1
+++ b/Windows/ProvisioningService.ps1
@@ -202,51 +202,41 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
         $sharedAesKey = [Convert]::FromBase64String(($sharedAesKeyBase64 -replace '\s', ''))
         $unwrappedAesKey = [Convert]::ToBase64String($rsa.Decrypt($sharedAesKey, $false))
 
-        # Define the keys to decrypt with new standardized names
-        $keysToDecrypt = @(
-            "hlvmm.data.guest_host_name",
-            "hlvmm.data.guest_v4_ip_addr",
-            "hlvmm.data.guest_v4_cidr_prefix",
-            "hlvmm.data.guest_v4_default_gw",
-            "hlvmm.data.guest_v4_dns1",
-            "hlvmm.data.guest_v4_dns2",
-            "hlvmm.data.guest_net_dns_suffix",
-            "hlvmm.data.guest_domain_join_target",
-            "hlvmm.data.guest_domain_join_uid",
-            "hlvmm.data.guest_domain_join_pw",
-            "hlvmm.data.guest_domain_join_ou",
-            "hlvmm.data.guest_la_uid",
-            "hlvmm.data.guest_la_pw"
-        )
-
-        # Create mapping from new KVP key names to legacy filenames for backward compatibility
-        $keyToFilenameMapping = @{
-            "hlvmm.data.guest_host_name"         = "guesthostname"
-            "hlvmm.data.guest_v4_ip_addr"        = "guestv4ipaddr"
-            "hlvmm.data.guest_v4_cidr_prefix"    = "guestv4cidrprefix"
-            "hlvmm.data.guest_v4_default_gw"     = "guestv4defaultgw"
-            "hlvmm.data.guest_v4_dns1"           = "guestv4dns1"
-            "hlvmm.data.guest_v4_dns2"           = "guestv4dns2"
-            "hlvmm.data.guest_net_dns_suffix"    = "guestnetdnssuffix"
-            "hlvmm.data.guest_domain_join_target" = "guestdomainjointarget"
-            "hlvmm.data.guest_domain_join_uid"   = "guestdomainjoinuid"
-            "hlvmm.data.guest_domain_join_pw"    = "guestdomainjoinpw"
-            "hlvmm.data.guest_domain_join_ou"    = "guestdomainjoinou"
-            "hlvmm.data.guest_la_uid"            = "guestlauid"
-            "hlvmm.data.guest_la_pw"             = "guestlapw"
+        # Get all hlvmm.data keys dynamically instead of using hardcoded list
+        $regPath = "HKLM:\SOFTWARE\Microsoft\Virtual Machine\External"
+        $hlvmmDataKeys = @()
+        
+        try {
+            $regItem = Get-Item -Path $regPath -ErrorAction SilentlyContinue
+            if ($regItem) {
+                $hlvmmDataKeys = $regItem.GetValueNames() | Where-Object { $_ -like "hlvmm.data.*" }
+            }
+        }
+        catch {
+            Write-Host "Error reading hlvmm.data keys from registry: $_"
+            exit
         }
 
-        # Decrypt and process each key
-        foreach ($key in $keysToDecrypt) {
+        if ($hlvmmDataKeys.Count -eq 0) {
+            Write-Host "No hlvmm.data keys found in KVP. Cannot proceed with provisioning."
+            exit
+        }
+
+        Write-Host "Found $($hlvmmDataKeys.Count) hlvmm.data keys to decrypt"
+
+        # Decrypt and save each key using its actual KVP key name
+        foreach ($key in $hlvmmDataKeys) {
             $encryptedValueBase64 = Read-HyperVKvp -Key $key -ErrorAction SilentlyContinue
             if (-not $encryptedValueBase64) {
                 Write-Host "Failed to retrieve encrypted value for key: $key. Skipping..."
                 continue
             }
             $decryptedValue = Decrypt-AesCbcWithPrependedIV -AesKey $unwrappedAesKey -CiphertextBase64 $encryptedValueBase64 -Output Utf8
-            $legacyFilename = $keyToFilenameMapping[$key]
-            $outputFilePath = [System.IO.Path]::Combine("C:\ProgramData\HyperV", "$legacyFilename.txt")
+            # Save using the actual KVP key name (replacing dots with underscores for valid filenames)
+            $safeFileName = $key -replace '\.', '_'
+            $outputFilePath = [System.IO.Path]::Combine("C:\ProgramData\HyperV", "$safeFileName.txt")
             [System.IO.File]::WriteAllText($outputFilePath, $decryptedValue)
+            Write-Host "Decrypted and saved: $key -> $safeFileName.txt"
         }
 
         # Get all hlvmm.data keys and their decrypted values for checksum verification
@@ -268,8 +258,8 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
         }
 
         #region: Configure hostname 
-        # Check if the "guesthostname" key exists and set the hostname
-        $guestHostNamePath = Join-Path -Path $decryptedKeysDir -ChildPath "guesthostname.txt"
+        # Check if the "hlvmm.data.guest_host_name" key exists and set the hostname
+        $guestHostNamePath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_host_name.txt"
         if (Test-Path $guestHostNamePath) {
             $guestHostName = Get-Content -Path $guestHostNamePath
             if ($guestHostName) {
@@ -277,25 +267,25 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
                 Write-Host "Hostname set to: $guestHostName"
             }
             else {
-                Write-Host "guesthostname file is empty. Skipping hostname configuration."
+                Write-Host "hlvmm.data.guest_host_name file is empty. Skipping hostname configuration."
             }
         }
         else {
-            Write-Host "guesthostname key does not exist. Skipping hostname configuration."
+            Write-Host "hlvmm.data.guest_host_name key does not exist. Skipping hostname configuration."
         }
         #endregion
         
         #region: Configure network
         # Check if the IP address is defined
-        $guestV4IpAddrPath = Join-Path -Path $decryptedKeysDir -ChildPath "guestv4ipaddr.txt"
+        $guestV4IpAddrPath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_v4_ip_addr.txt"
         if (Test-Path $guestV4IpAddrPath) {
             $guestV4IpAddr = Get-Content -Path $guestV4IpAddrPath
             if ($guestV4IpAddr) {
                 # Retrieve other network settings
-                $guestV4CidrPrefix = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "guestv4cidrprefix.txt")
-                $guestV4DefaultGw = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "guestv4defaultgw.txt")
-                $guestV4Dns1 = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "guestv4dns1.txt")
-                $guestV4Dns2 = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "guestv4dns2.txt")
+                $guestV4CidrPrefix = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_v4_cidr_prefix.txt")
+                $guestV4DefaultGw = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_v4_default_gw.txt")
+                $guestV4Dns1 = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_v4_dns1.txt")
+                $guestV4Dns2 = Get-Content -Path (Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_v4_dns2.txt")
 
                 # Configure the network adapter
                 $adapter = Get-NetAdapter | Where-Object { $_.Status -eq "Up" }
@@ -310,22 +300,22 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
                 }
             }
             else {
-                Write-Host "guestv4ipaddr file is empty. Skipping network configuration."
+                Write-Host "hlvmm.data.guest_v4_ip_addr file is empty. Skipping network configuration."
             }
         }
         else {
-            Write-Host "guestv4ipaddr key does not exist. Skipping network configuration."
+            Write-Host "hlvmm.data.guest_v4_ip_addr key does not exist. Skipping network configuration."
         }
         #endregion
 
         #region: Configure local account
-        # Check if the "guestlauid" key exists
-        $guestLaUidPath = Join-Path -Path $decryptedKeysDir -ChildPath "guestlauid.txt"
+        # Check if the "hlvmm.data.guest_la_uid" key exists
+        $guestLaUidPath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_la_uid.txt"
         if (Test-Path $guestLaUidPath) {
             $guestLaUid = Get-Content -Path $guestLaUidPath
             if ($guestLaUid) {
                 # Retrieve the password for the account
-                $guestLaPwPath = Join-Path -Path $decryptedKeysDir -ChildPath "guestlapw.txt"
+                $guestLaPwPath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_la_pw.txt"
                 if (Test-Path $guestLaPwPath) {
                     $guestLaPw = Get-Content -Path $guestLaPwPath
                     if ($guestLaPw) {
@@ -353,19 +343,19 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
                         }
                     }
                     else {
-                        Write-Host "guestlapw file is empty. Skipping local account configuration."
+                        Write-Host "hlvmm.data.guest_la_pw file is empty. Skipping local account configuration."
                     }
                 }
                 else {
-                    Write-Host "guestlapw key does not exist. Skipping local account configuration."
+                    Write-Host "hlvmm.data.guest_la_pw key does not exist. Skipping local account configuration."
                 }
             }
             else {
-                Write-Host "guestlauid file is empty. Skipping local account configuration."
+                Write-Host "hlvmm.data.guest_la_uid file is empty. Skipping local account configuration."
             }
         }
         else {
-            Write-Host "guestlauid key does not exist. Skipping local account configuration."
+            Write-Host "hlvmm.data.guest_la_uid key does not exist. Skipping local account configuration."
         }
         #endregion
 
@@ -374,15 +364,15 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
     "phase_one" {
         "phase_two" | Set-Content -Path $PhaseFile -Encoding UTF8
 
-        # Check if the "guestdomainjointarget" key exists
-        $guestDomainJoinTargetPath = Join-Path -Path $decryptedKeysDir -ChildPath "guestdomainjointarget.txt"
+        # Check if the "hlvmm.data.guest_domain_join_target" key exists
+        $guestDomainJoinTargetPath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_domain_join_target.txt"
         if (Test-Path $guestDomainJoinTargetPath) {
             $guestDomainJoinTarget = Get-Content -Path $guestDomainJoinTargetPath
             if ($guestDomainJoinTarget) {
                 # Retrieve the domain join credentials
-                $guestDomainJoinUidPath = Join-Path -Path $decryptedKeysDir -ChildPath "guestdomainjoinuid.txt"
-                $guestDomainJoinPwPath = Join-Path -Path $decryptedKeysDir -ChildPath "guestdomainjoinpw.txt"
-                $guestDomainJoinOUPath = Join-Path -Path $decryptedKeysDir -ChildPath "guestdomainjoinou.txt"
+                $guestDomainJoinUidPath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_domain_join_uid.txt"
+                $guestDomainJoinPwPath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_domain_join_pw.txt"
+                $guestDomainJoinOUPath = Join-Path -Path $decryptedKeysDir -ChildPath "hlvmm_data_guest_domain_join_ou.txt"
 
                 if ((Test-Path $guestDomainJoinUidPath) -and (Test-Path $guestDomainJoinPwPath) -and (Test-Path $guestDomainJoinOUPath)) {
                     $guestDomainJoinUid = (Get-Content -Path $guestDomainJoinUidPath).Trim()
@@ -422,7 +412,7 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
                             $TaskName = "ProvisioningService"
                             Disable-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
                             
-                            Get-ChildItem -Path $decryptedKeysDir -Filter "guest*.txt" | Remove-Item -Force -ErrorAction SilentlyContinue
+                            Get-ChildItem -Path $decryptedKeysDir -Filter "hlvmm_data_*.txt" | Remove-Item -Force -ErrorAction SilentlyContinue
                             Restart-Computer -Force
                         }
                         catch {
@@ -438,18 +428,18 @@ switch (Get-Content -Path $PhaseFile -Encoding UTF8) {
                 }
             }
             else {
-                Write-Host "guestdomainjointarget file is empty. Skipping domain join."
+                Write-Host "hlvmm.data.guest_domain_join_target file is empty. Skipping domain join."
             }
         }
         else {
-            Write-Host "guestdomainjointarget key does not exist. Skipping domain join."
+            Write-Host "hlvmm.data.guest_domain_join_target key does not exist. Skipping domain join."
             "phase_two" | Set-Content -Path $PhaseFile -Encoding UTF8
             $TaskName = "ProvisioningService"
             Write-Host "Disabling scheduled task $TaskName..."
             Disable-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
             Write-Host "Scheduled task $TaskName has been disabled."
 
-            Get-ChildItem -Path $decryptedKeysDir -Filter "guest*.txt" | Remove-Item -Force -ErrorAction SilentlyContinue
+            Get-ChildItem -Path $decryptedKeysDir -Filter "hlvmm_data_*.txt" | Remove-Item -Force -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the Linux and PowerShell scripts for VM provisioning to standardize key-value pair (KVP) names, dynamically handle provisioning data keys, and ensure checksum calculation and verification are consistent between Windows and Linux. The changes improve reliability, maintainability, and cross-platform compatibility by eliminating hardcoded key lists, using sorted keys for checksum, and updating key naming conventions.

**KVP Key Naming Standardization:**

* All KVP keys in both Linux (`user-data`) and PowerShell (`PublishProvisioningData.ps1`) scripts are renamed to use the `hlvmm.meta.*` and `hlvmm.data.*` conventions, replacing previous names like `guestprovisioningpublickey`, `guestprovisioningsystemstate`, and `sharedaeskey`. [[1]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L176-R182) [[2]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L247-R271) [[3]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L289-R289) [[4]](diffhunk://#diff-cf84626b0f56de1d4e5bd4884d8890cfb0573936d40b7b0fcf975bcc34c36d8dL308-R331) [[5]](diffhunk://#diff-cf84626b0f56de1d4e5bd4884d8890cfb0573936d40b7b0fcf975bcc34c36d8dL330-R353) [[6]](diffhunk://#diff-cf84626b0f56de1d4e5bd4884d8890cfb0573936d40b7b0fcf975bcc34c36d8dL354-R378)

**Dynamic Handling of Provisioning Data Keys:**

* The Linux script now discovers all `hlvmm.data.*` keys dynamically from the KVP pool file, rather than relying on a hardcoded list. This makes the script more flexible and future-proof.
* Decryption and file storage of provisioning data is updated to use the actual KVP key names, with safe filenames generated by replacing dots with underscores. [[1]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L356-R373) [[2]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L373-R382) [[3]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L387-R409)

**Checksum Calculation and Verification Consistency:**

* Both scripts now calculate the provisioning data checksum by concatenating all non-empty `hlvmm.data.*` values in sorted key order, ensuring consistent cross-platform results. The Linux script includes debug output for troubleshooting, and the PowerShell script builds the list of keys to publish/checksum dynamically. [[1]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L414-R506) [[2]](diffhunk://#diff-cf84626b0f56de1d4e5bd4884d8890cfb0573936d40b7b0fcf975bcc34c36d8dL277-R322)
* The checksum is published to the KVP under the new standardized key name `hlvmm.meta.provisioning_system_checksum`. [[1]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L414-R506) [[2]](diffhunk://#diff-cf84626b0f56de1d4e5bd4884d8890cfb0573936d40b7b0fcf975bcc34c36d8dL308-R331)

**Configuration and Usage Updates:**

* All references to decrypted provisioning data files in the Linux script are updated to use the new safe filenames, ensuring correct handling in user account, domain join, network, and hostname configuration steps. [[1]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L414-R506) [[2]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L477-R544) [[3]](diffhunk://#diff-c9369b50d5229e4d68b9676c18cb630616ffc075373630c202912ba763fed222L555-R611)

These changes improve the maintainability and correctness of the VM provisioning process, making it easier to extend and debug across platforms.